### PR TITLE
Add enhancement evid8

### DIFF
--- a/cmdstan/stan/lib/stan_math/stan/math/torsten/event_history.hpp
+++ b/cmdstan/stan/lib/stan_math/stan/math/torsten/event_history.hpp
@@ -217,6 +217,10 @@ namespace torsten {
       return evid(i) == 1 || evid(i) == 4;
     }
 
+    bool is_replace(int i) const {   // enhancement evid 8
+      return evid(i) == 8;
+    }
+
     /*
      * if an event is steady-state dosing event.
      */

--- a/cmdstan/stan/lib/stan_math/stan/math/torsten/event_solver.hpp
+++ b/cmdstan/stan/lib/stan_math/stan/math/torsten/event_solver.hpp
@@ -67,6 +67,7 @@ namespace torsten{
      *                    (2) other
      *                    (3) reset
      *                    (4) reset AND dosing
+     *                    (8) replace
      * @param[in] cmt compartment number at each event (starts at 1)
      * @param[in] addl additional dosing at each event
      * @param[in] ss steady state approximation at each event
@@ -160,6 +161,9 @@ namespace torsten{
       if (events.is_bolus_dosing(i)) {
         init(0, events.cmt(i) - 1) += events.fractioned_amt(i);
       }
+      if (events.is_replace(i)){   // enhancement evid 8
+        init(0, events.cmt(i) - 1) = events.fractioned_amt(i);
+      }
       tprev = events.time(i);
     }
 
@@ -199,6 +203,9 @@ namespace torsten{
       if (events.is_bolus_dosing(i)) {
         init(0, events.cmt(i) - 1) += events.fractioned_amt(i);
       }
+      if (events.is_replace(i)){
+        init(0, events.cmt(i) - 1) = events.fractioned_amt(i);
+      }
       tprev = events.time(i);
     }
 
@@ -237,6 +244,9 @@ namespace torsten{
 
       if (events.is_bolus_dosing(i)) {
         init(0, events.cmt(i) - 1) += events.fractioned_amt(i);
+      }
+      if (events.is_replace(i)){
+        init(0, events.cmt(i) - 1) = events.fractioned_amt(i);
       }
     }
 
@@ -278,7 +288,7 @@ namespace torsten{
 
       std::vector<MPI_Request> req(np);
       vector<MatrixXd> res_d(np);
-      
+
       res.resize(nCmt, events_rec.total_num_event_times);
 
       PKRec<scalar> init(nCmt);
@@ -389,7 +399,7 @@ namespace torsten{
               iev++;
             }
           }
-        } 
+        }
       }
 
       MPI_Barrier(comm);
@@ -510,7 +520,7 @@ namespace torsten{
 
       const int nCmt = EM::nCmt(events_rec);
       const int np = events_rec.num_subjects();
-      
+
       res.resize(nCmt, events_rec.total_num_event_times);
 
       static bool has_warning = false;


### PR DESCRIPTION
This commit references to usage of EVID issue #9 . 
It is a minimal change in event_history.hpp and even_solver.cpp to define is_replace to implement EVID =8 as it is implemented in mrgsolve. See  https://mrgsolve.github.io/user_guide/input-data-sets.html