### PR TITLE
tests: add script to check that stanc3 recognizes entry points

### DIFF
--- a/tests/check-entrypoints.sh
+++ b/tests/check-entrypoints.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -eu
+
+# Check that stanc3 recognizes each of the entry points below by
+# injecting the entry point into a dummy model and verifying that
+# stanc3 doesn't complain about an undeclared identifier.
+
+entrypoints='
+pmx_ln_interpolate
+pmx_ode_adams
+pmx_ode_adams_ctrl
+pmx_ode_bdf
+pmx_ode_bdf_ctrl
+pmx_ode_ckrk
+pmx_ode_ckrk_ctrl
+pmx_ode_rk45
+pmx_ode_rk45_ctrl
+pmx_solve_adams
+pmx_solve_bdf
+pmx_solve_group_adams
+pmx_solve_group_bdf
+pmx_solve_group_rk45
+pmx_solve_linode
+pmx_solve_onecpt
+pmx_solve_onecpt_bdf
+pmx_solve_onecpt_effcpt
+pmx_solve_onecpt_rk45
+pmx_solve_rk45
+pmx_solve_twocpt
+pmx_solve_twocpt_bdf
+pmx_solve_twocpt_effcpt
+pmx_solve_twocpt_rk45
+'
+
+test -d stanc3 || {
+    printf >&2 '%s must be called from top of Torsten repository\n'  "$0"
+    exit 2
+}
+
+STANC3=$PWD/stanc3
+export STANC3
+
+command -v ocaml >/dev/null || {
+    printf >&2 'ocaml not in PATH; is the stanc3 dev environment activated?\n'
+    exit 2
+}
+
+tdir=$(mktemp -d "${TMPDIR:-/tmp}"/torsten-check-entrypoints-XXXXX)
+trap 'rm -rf "$tdir"' 0
+
+printf >&2 'building cmdstan...\n'
+make -C cmdstan -j "$(nproc)" build >/dev/null 2>"$tdir/build-stderr" || {
+    cat >&2 "$tdir/build-stderr"
+    exit 2
+}
+
+build_model () {
+    cat<<EOF >"$tdir"/dummy.stan
+transformed parameters {
+ real x = $1();
+}
+EOF
+    # shellcheck disable=SC2069
+    make -C cmdstan "$tdir"/dummy 2>&1 >/dev/null
+}
+
+IFS='
+'
+failed=
+for e in $entrypoints
+do
+    printf >&2 '%s...'  "$e"
+    if build_model "$e" | grep -q 'undeclared identifier'
+    then
+        printf 'FAILED\n'
+        failed=1
+    else
+        printf 'ok\n'
+    fi
+done
+test -z "$failed"


### PR DESCRIPTION
For each Torsten entry point exposed via stanc3, it'd be good to have an indication that it's wired up correctly.  This is already the case for entry points that are covered in example-models/.  However, it probably isn't worth adding and maintaining an example for every case just to check that all entry points are recognized.

Instead add a script that creates a non-functional dummy model for each entry point and verifies that building the model does not fail with the "undeclared identifier" error that stanc3 would emit if it didn't recognize the entry point at all.

The limitations of this script are that

  1) it relies on stanc3 emitting a particular error message, so a
     stanc3 update could lead to it silently passing

  2) similarly, it relies on stanc3 not signaling some an unrelated
     error _before_ the undeclared identifier error

  3) it requires keeping the list of entry points in the script up to
     date.  That's not so bad when removing/renaming an entry point,
     because the script will fail loudly, but there is a risk of
     forgetting to add a new entry point.